### PR TITLE
fix: externalize config to environment variables

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,8 +5,8 @@ server:
 spring:
   data:
     mongodb:
-      uri: mongodb://61.14.234.12:27017/admin_db
+      uri: ${MONGODB_URI:mongodb://61.14.234.12:27017/admin_db}
 app:
   jwt:
-    secret: "12345678901234567890123456789012"
-    expiration-ms: 86400000
+    secret: ${JWT_SECRET:12345678901234567890123456789012}
+    expiration-ms: ${JWT_EXPIRATION_MS:86400000}


### PR DESCRIPTION
## Summary
- Thay `MONGODB_URI`, `JWT_SECRET`, `JWT_EXPIRATION_MS` bằng env vars
- Giữ default values để không breaking khi chạy local

Closes #3