### PR TITLE
fix: change default MongoDB URI to localhost

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ server:
 spring:
   data:
     mongodb:
-      uri: ${MONGODB_URI:mongodb://61.14.234.12:27017/admin_db}
+      uri: ${MONGODB_URI:mongodb://localhost:27017/admin_db}
 app:
   jwt:
     secret: ${JWT_SECRET:12345678901234567890123456789012}


### PR DESCRIPTION
## Summary
- Đổi default `MONGODB_URI` từ `mongodb://61.14.234.12:27017/admin_db` → `mongodb://localhost:27017/admin_db`

Closes #5