### PR TITLE
fix: add MongoDB service container to CI build job

### DIFF
--- a/.github/workflows/git-action.yml
+++ b/.github/workflows/git-action.yml
@@ -9,6 +9,11 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       IMAGE_TAG: ${{ steps.tag.outputs.IMAGE_TAG }}
+    services:
+      mongodb:
+        image: mongo:7
+        ports:
+          - 27017:27017
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4


### PR DESCRIPTION
## Summary
- Test `contextLoads` fail vì CI không có MongoDB running
- Thêm `mongo:7` service container vào build job, expose port `27017`
- Không cần sửa code hay thêm dependency

Closes #7