### PR TITLE
fix: resolve Spring 6.2 PlaceholderResolutionException for oauth2 frontend-redirect-uri

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,4 +26,4 @@ app:
     secret: ${JWT_SECRET:12345678901234567890123456789012}
     expiration-ms: ${JWT_EXPIRATION_MS:86400000}
   oauth2:
-    frontend-redirect-uri: ${FRONTEND_REDIRECT_URI:http://localhost:3000/oauth2/callback}
+    frontend-redirect-uri: http://localhost:3000/oauth2/callback


### PR DESCRIPTION
## Problem

Spring 6.2.12 (Boot 3.5) introduced a stricter `PlaceholderParser` that fails when a YAML property value contains `${ENV_VAR:http://...}` with `://` in the default **and** the env var is not set. This caused:

```
Could not resolve placeholder 'app.oauth2.frontend-redirect-uri'
```

## Fix

Hardcode the default value directly in `application.yml`:

```yaml
app:
  oauth2:
    frontend-redirect-uri: http://localhost:3000/oauth2/callback
```

For production override, use Spring Boot relaxed binding env var:
```bash
APP_OAUTH2_FRONTEND_REDIRECT_URI=https://your-domain.com/oauth2/callback
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)