### PR TITLE
fix: resolve OAuth2 OIDC ClassCastException and circular bean dependency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,22 +36,35 @@ Spring Boot 3.5.7 REST API (Java 21) with JWT authentication, MongoDB persistenc
 **Layer structure:**
 - `controller/` — `AuthController` (public: `/auth/register`, `/auth/login`), `AdminController` (protected: `/user/profile`, `/admin/secret`, `/public/hello`)
 - `security/` — `JwtService` (HMAC-SHA256 token generation/validation), `JwtAuthenticationFilter`, `CustomUserDetailsService`, `CustomUserDetails`
-- `config/` — `SecurityConfig` (filter chain, CORS, CSRF-off, stateless sessions, `@PreAuthorize` method security), `AppConfig`
-- `entity/` — `User` and `Role` MongoDB documents; `Role` linked via `@DBRef`
-- `repository/` — Spring Data MongoDB repositories; `UserRepository.findByUsername()`
+- `config/` — `SecurityConfig` (filter chain, CORS, CSRF-off, stateless sessions, `@PreAuthorize` method security), `AppConfig` (`PasswordEncoder` bean + seed admin user)
+- `security/` — `CustomOAuth2UserService` (non-OIDC OAuth2 user load/create), `CustomOidcUserService`, `OAuth2LoginSuccessHandler`, `CookieOAuth2AuthorizationRequestRepository`
+- `entity/` — `User` and `Role` MongoDB documents; `Role` linked via `@DBRef`; `User` có `provider` + `providerId` cho OAuth2
+- `repository/` — Spring Data MongoDB repositories; `UserRepository.findByUsername()`, `findByEmail()`, `findByProviderAndProviderId()`
 - `dto/` — `RegisterRequest`, `LoginRequest`, `AuthResponse`, `UserDto`
 
 **Authorization model:** Role-based via Spring `@PreAuthorize`. Roles stored in MongoDB `Role` collection and referenced from `User`.
+
+**OAuth2 / Google login flow:**
+- Google dùng OIDC (có scope `openid`) → Spring Security gọi `OidcUserService` mặc định, principal là `DefaultOidcUser`
+- `OAuth2LoginSuccessHandler` dùng `instanceof` pattern để handle cả 2 loại principal: `CustomOAuth2UserDetails` (non-OIDC) và `DefaultOidcUser` (OIDC/Google)
+- Khi gặp `DefaultOidcUser`, gọi `CustomOAuth2UserService.findOrCreateUser()` để tìm/tạo user trong MongoDB
+- `PasswordEncoder` bean đặt trong `AppConfig` (không phải `SecurityConfig`) để tránh circular dependency: `SecurityConfig` → `CustomOAuth2UserService` → `PasswordEncoder` → `SecurityConfig`
+- Redirect sau login: `{frontend-redirect-uri}?token={jwt}&username={username}`
 
 ## Configuration
 
 `src/main/resources/application.yml` contains MongoDB URI and JWT settings. Override via environment variables in production:
 
 ```yaml
-spring.data.mongodb.uri    # MongoDB connection
-app.jwt.secret             # 32-char HMAC secret
-app.jwt.expiration-ms      # Token TTL (default: 86400000 = 24h)
+spring.data.mongodb.uri                          # MongoDB connection
+app.jwt.secret                                   # 32-char HMAC secret
+app.jwt.expiration-ms                            # Token TTL (default: 86400000 = 24h)
+GOOGLE_CLIENT_ID                                 # Google OAuth2 client ID
+GOOGLE_CLIENT_SECRET                             # Google OAuth2 client secret
+app.oauth2.frontend-redirect-uri                 # Frontend callback URL (e.g. http://localhost:5174/oauth2/callback)
 ```
+
+**Google Cloud Console:** Authorized redirect URI phải là `{baseUrl}/api/login/oauth2/code/google` (chú ý prefix `/api` theo context-path).
 
 ## Git Workflows
 

--- a/src/main/java/com/hub/api/admin/config/AppConfig.java
+++ b/src/main/java/com/hub/api/admin/config/AppConfig.java
@@ -7,12 +7,18 @@ import com.hub.api.admin.repository.UserRepository;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Set;
 
 @Configuration
 public class AppConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 
     @Bean
     CommandLineRunner initAdmin(RoleRepository roleRepository,

--- a/src/main/java/com/hub/api/admin/config/SecurityConfig.java
+++ b/src/main/java/com/hub/api/admin/config/SecurityConfig.java
@@ -13,8 +13,6 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -24,26 +22,18 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
-    private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
     private final CookieOAuth2AuthorizationRequestRepository cookieRepo;
     private final String frontendRedirectUri;
 
     public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter,
-                          CustomOAuth2UserService customOAuth2UserService,
                           OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler,
                           CookieOAuth2AuthorizationRequestRepository cookieRepo,
                           @Value("${app.oauth2.frontend-redirect-uri}") String frontendRedirectUri) {
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
-        this.customOAuth2UserService = customOAuth2UserService;
         this.oAuth2LoginSuccessHandler = oAuth2LoginSuccessHandler;
         this.cookieRepo = cookieRepo;
         this.frontendRedirectUri = frontendRedirectUri;
-    }
-
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
     }
 
     @Bean
@@ -53,8 +43,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, CustomOAuth2UserService customOAuth2UserService) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(cors -> {

--- a/src/main/java/com/hub/api/admin/security/CustomOAuth2UserDetails.java
+++ b/src/main/java/com/hub/api/admin/security/CustomOAuth2UserDetails.java
@@ -1,7 +1,7 @@
 package com.hub.api.admin.security;
 
-import com.hub.api.admin.entity.Role;
 import com.hub.api.admin.entity.User;
+import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -13,6 +13,7 @@ import java.util.stream.Stream;
 
 public class CustomOAuth2UserDetails implements OAuth2User {
 
+    @Getter
     private final User user;
     private final Map<String, Object> attributes;
 
@@ -45,7 +46,4 @@ public class CustomOAuth2UserDetails implements OAuth2User {
         return user.getProviderId();
     }
 
-    public User getUser() {
-        return user;
-    }
 }

--- a/src/main/java/com/hub/api/admin/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/hub/api/admin/security/CustomOAuth2UserService.java
@@ -44,7 +44,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         return new CustomOAuth2UserDetails(user, attributes);
     }
 
-    private User findOrCreateUser(String providerId, String email, Map<String, Object> attributes) {
+    public User findOrCreateUser(String providerId, String email, Map<String, Object> attributes) {
         // Link tới existing local account nếu email trùng
         return userRepository.findByEmail(email)
                 .map(existingUser -> {

--- a/src/main/java/com/hub/api/admin/security/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/hub/api/admin/security/OAuth2LoginSuccessHandler.java
@@ -5,29 +5,34 @@ import com.hub.api.admin.entity.Role;
 import com.hub.api.admin.entity.User;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Component
+@Slf4j
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private final JwtService jwtService;
     private final CookieOAuth2AuthorizationRequestRepository cookieRepo;
+    private final CustomOAuth2UserService customOAuth2UserService;
     private final String frontendRedirectUri;
 
     public OAuth2LoginSuccessHandler(
             JwtService jwtService,
             CookieOAuth2AuthorizationRequestRepository cookieRepo,
+            CustomOAuth2UserService customOAuth2UserService,
             @Value("${app.oauth2.frontend-redirect-uri}") String frontendRedirectUri) {
         this.jwtService = jwtService;
         this.cookieRepo = cookieRepo;
+        this.customOAuth2UserService = customOAuth2UserService;
         this.frontendRedirectUri = frontendRedirectUri;
     }
 
@@ -35,24 +40,34 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     public void onAuthenticationSuccess(HttpServletRequest request,
                                         HttpServletResponse response,
                                         Authentication authentication) throws IOException {
-        CustomOAuth2UserDetails oAuth2UserDetails =
-                (CustomOAuth2UserDetails) authentication.getPrincipal();
-        User user = oAuth2UserDetails.getUser();
+        OAuth2User principal = (OAuth2User) authentication.getPrincipal();
+
+        User user;
+        if (principal instanceof CustomOAuth2UserDetails details) {
+            user = details.getUser();
+        } else {
+            Map<String, Object> attributes = principal.getAttributes();
+            String providerId = (String) attributes.get("sub");
+            String email = (String) attributes.get("email");
+            user = customOAuth2UserService.findOrCreateUser(providerId, email, attributes);
+        }
+
+        log.info("OAuth2 login successful for user: {}", user.getEmail());
 
         List<String> roles = user.getRoles().stream()
                 .map(Role::getName)
-                .collect(Collectors.toList());
+                .toList();
         List<String> permissions = user.getRoles().stream()
                 .flatMap(r -> r.getPermissions().stream())
                 .map(Permission::getName)
                 .distinct()
-                .collect(Collectors.toList());
+                .toList();
 
         Map<String, Object> extraClaims = Map.of("roles", roles, "permissions", permissions);
         String jwt = jwtService.generateToken(new CustomUserDetails(user), extraClaims);
 
         cookieRepo.removeAuthorizationRequest(request, response);
 
-        response.sendRedirect(frontendRedirectUri + "?token=" + jwt);
+        response.sendRedirect(frontendRedirectUri + "?token=" + jwt  + "&username=" + user.getUsername());
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,13 +11,13 @@ spring:
       client:
         registration:
           google:
-            client-id: ${GOOGLE_CLIENT_ID:your-google-client-id}
-            client-secret: ${GOOGLE_CLIENT_SECRET:your-google-client-secret}
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
             scope:
               - openid
               - profile
               - email
-            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            redirect-uri: ${GOOGLE_REDIRECT_URI:http://localhost:8080/api/login/oauth2/code/google}
         provider:
           google:
             user-name-attribute: sub
@@ -26,4 +26,4 @@ app:
     secret: ${JWT_SECRET:12345678901234567890123456789012}
     expiration-ms: ${JWT_EXPIRATION_MS:86400000}
   oauth2:
-    frontend-redirect-uri: http://localhost:3000/oauth2/callback
+    frontend-redirect-uri: ${FRONTEND_REDIRECT_URI:http://localhost:5174/oauth2/callback}


### PR DESCRIPTION
Closes #16

## Summary
- Move `PasswordEncoder` bean to `AppConfig` to break circular dependency between `SecurityConfig` and `CustomOAuth2UserService`
- Fix `OAuth2LoginSuccessHandler` to handle `DefaultOidcUser` (Google OIDC flow) using `instanceof` pattern matching
- Remove hardcoded Google credentials from `application.yml`
- Update `CLAUDE.md` with OAuth2/OIDC flow notes and env var documentation

## Root Cause
Google OAuth2 uses OIDC (OpenID Connect) because of the `openid` scope. Spring Security routes through `OidcUserService` internally — not our custom `DefaultOAuth2UserService` — so `getPrincipal()` returns `DefaultOidcUser`, causing a `ClassCastException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)