### PR TITLE
fix: OAuth2 intermittent failure - SameSite cookie + failure logging

### DIFF
--- a/src/main/java/com/hub/api/admin/config/SecurityConfig.java
+++ b/src/main/java/com/hub/api/admin/config/SecurityConfig.java
@@ -3,8 +3,8 @@ package com.hub.api.admin.config;
 import com.hub.api.admin.security.CookieOAuth2AuthorizationRequestRepository;
 import com.hub.api.admin.security.CustomOAuth2UserService;
 import com.hub.api.admin.security.JwtAuthenticationFilter;
+import com.hub.api.admin.security.OAuth2LoginFailureHandler;
 import com.hub.api.admin.security.OAuth2LoginSuccessHandler;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -14,7 +14,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
@@ -23,17 +22,17 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
     private final CookieOAuth2AuthorizationRequestRepository cookieRepo;
-    private final String frontendRedirectUri;
 
     public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter,
                           OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler,
-                          CookieOAuth2AuthorizationRequestRepository cookieRepo,
-                          @Value("${app.oauth2.frontend-redirect-uri}") String frontendRedirectUri) {
+                          OAuth2LoginFailureHandler oAuth2LoginFailureHandler,
+                          CookieOAuth2AuthorizationRequestRepository cookieRepo) {
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
         this.oAuth2LoginSuccessHandler = oAuth2LoginSuccessHandler;
+        this.oAuth2LoginFailureHandler = oAuth2LoginFailureHandler;
         this.cookieRepo = cookieRepo;
-        this.frontendRedirectUri = frontendRedirectUri;
     }
 
     @Bean
@@ -62,8 +61,7 @@ public class SecurityConfig {
                         .authorizationEndpoint(a -> a.authorizationRequestRepository(cookieRepo))
                         .userInfoEndpoint(u -> u.userService(customOAuth2UserService))
                         .successHandler(oAuth2LoginSuccessHandler)
-                        .failureHandler(new SimpleUrlAuthenticationFailureHandler(
-                                frontendRedirectUri + "?error=oauth2_failed"))
+                        .failureHandler(oAuth2LoginFailureHandler)
                 )
                 .addFilterBefore(jwtAuthenticationFilter,
                         UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/hub/api/admin/security/CookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/hub/api/admin/security/CookieOAuth2AuthorizationRequestRepository.java
@@ -1,6 +1,5 @@
 package com.hub.api.admin.security;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -38,6 +37,7 @@ public class CookieOAuth2AuthorizationRequestRepository
         cookie.setPath("/");
         cookie.setHttpOnly(true);
         cookie.setMaxAge(COOKIE_MAX_AGE);
+        cookie.setAttribute("SameSite", "Lax");
         response.addCookie(cookie);
     }
 

--- a/src/main/java/com/hub/api/admin/security/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/hub/api/admin/security/OAuth2LoginFailureHandler.java
@@ -1,0 +1,29 @@
+package com.hub.api.admin.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@Slf4j
+public class OAuth2LoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    public OAuth2LoginFailureHandler(@Value("${app.oauth2.frontend-redirect-uri}") String frontendRedirectUri) {
+        super(frontendRedirectUri + "?error=oauth2_failed");
+    }
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException, ServletException {
+        log.error("OAuth2 login failed: {}", exception.getMessage(), exception);
+        super.onAuthenticationFailure(request, response, exception);
+    }
+}


### PR DESCRIPTION
## Summary

- Thêm `SameSite=Lax` vào cookie `oauth2_auth_request` để fix lỗi intermittent khi browser block cookie trong cross-site redirect
- Thêm `OAuth2LoginFailureHandler` log exception thực sự thay vì chỉ redirect mà không biết lý do

Closes #20

## Test plan

- [ ] Login Google nhiều lần liên tiếp → không còn lỗi intermittent
- [ ] Khi có lỗi, server log hiển thị exception cụ thể