### PR TITLE
fix: set Secure flag on OAuth2 cookie to resolve intermittent login failure

### DIFF
--- a/src/main/java/com/hub/api/admin/security/CookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/hub/api/admin/security/CookieOAuth2AuthorizationRequestRepository.java
@@ -30,13 +30,14 @@ public class CookieOAuth2AuthorizationRequestRepository
                                          HttpServletRequest request,
                                          HttpServletResponse response) {
         if (authorizationRequest == null) {
-            deleteCookie(response);
+            deleteCookie(request, response);
             return;
         }
         Cookie cookie = new Cookie(COOKIE_NAME, serialize(authorizationRequest));
         cookie.setPath("/");
         cookie.setHttpOnly(true);
         cookie.setMaxAge(COOKIE_MAX_AGE);
+        cookie.setSecure(isSecureRequest(request));
         cookie.setAttribute("SameSite", "Lax");
         response.addCookie(cookie);
     }
@@ -45,7 +46,7 @@ public class CookieOAuth2AuthorizationRequestRepository
     public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request,
                                                                   HttpServletResponse response) {
         OAuth2AuthorizationRequest authRequest = loadAuthorizationRequest(request);
-        deleteCookie(response);
+        deleteCookie(request, response);
         return authRequest;
     }
 
@@ -57,11 +58,18 @@ public class CookieOAuth2AuthorizationRequestRepository
                 .findFirst();
     }
 
-    private void deleteCookie(HttpServletResponse response) {
+    private boolean isSecureRequest(HttpServletRequest request) {
+        return request.isSecure()
+                || "https".equalsIgnoreCase(request.getHeader("X-Forwarded-Proto"));
+    }
+
+    private void deleteCookie(HttpServletRequest request, HttpServletResponse response) {
         Cookie cookie = new Cookie(COOKIE_NAME, "");
         cookie.setPath("/");
         cookie.setHttpOnly(true);
         cookie.setMaxAge(0);
+        cookie.setSecure(isSecureRequest(request));
+        cookie.setAttribute("SameSite", "Lax");
         response.addCookie(cookie);
     }
 
@@ -70,7 +78,11 @@ public class CookieOAuth2AuthorizationRequestRepository
     }
 
     private OAuth2AuthorizationRequest deserialize(String value) {
-        return (OAuth2AuthorizationRequest) SerializationUtils.deserialize(
-                Base64.getUrlDecoder().decode(value));
+        try {
+            return (OAuth2AuthorizationRequest) SerializationUtils.deserialize(
+                    Base64.getUrlDecoder().decode(value));
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,7 @@ server:
   port: ${ADMIN_API_PORT:8080}
   servlet:
     context-path: /api
+  forward-headers-strategy: NATIVE
 spring:
   data:
     mongodb:


### PR DESCRIPTION
## Summary

- Add `server.forward-headers-strategy: NATIVE` so Spring Boot trusts `X-Forwarded-Proto` from nginx ingress
- Set `Secure` flag on `oauth2_auth_request` cookie when request comes over HTTPS
- Fix cookie deletion to use same attributes (`Secure`, `SameSite`) for consistency
- Wrap cookie deserialization in try-catch to handle corrupt cookies gracefully

Closes #22

## Test plan

- [ ] Login với Google trên `https://www.devapihub.com` nhiều lần liên tiếp, không còn lỗi `authorization_request_not_found`
- [ ] Login local (HTTP) vẫn hoạt động bình thường (cookie không có Secure flag khi chạy local)
- [ ] Kiểm tra DevTools → Application → Cookies: cookie `oauth2_auth_request` có `Secure` flag khi trên HTTPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)