### PR TITLE
fix: add diagnostic logging to OAuth2 cookie repository

### DIFF
--- a/src/main/java/com/hub/api/admin/security/CookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/hub/api/admin/security/CookieOAuth2AuthorizationRequestRepository.java
@@ -3,6 +3,7 @@ package com.hub.api.admin.security;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.stereotype.Component;
@@ -11,6 +12,7 @@ import org.springframework.util.SerializationUtils;
 import java.util.Arrays;
 import java.util.Base64;
 
+@Slf4j
 @Component
 public class CookieOAuth2AuthorizationRequestRepository
         implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
@@ -20,9 +22,20 @@ public class CookieOAuth2AuthorizationRequestRepository
 
     @Override
     public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
-        return getCookieValue(request, COOKIE_NAME)
-                .map(this::deserialize)
-                .orElse(null);
+        java.util.Optional<String> cookieValue = getCookieValue(request, COOKIE_NAME);
+        if (cookieValue.isEmpty()) {
+            String cookieNames = request.getCookies() == null ? "none" :
+                    Arrays.stream(request.getCookies()).map(Cookie::getName).toList().toString();
+            log.warn("[OAuth2] loadAuthorizationRequest: cookie '{}' NOT found. uri={}, presentCookies={}",
+                    COOKIE_NAME, request.getRequestURI(), cookieNames);
+            return null;
+        }
+        log.debug("[OAuth2] loadAuthorizationRequest: cookie found, valueLength={}", cookieValue.get().length());
+        OAuth2AuthorizationRequest authRequest = deserialize(cookieValue.get());
+        if (authRequest == null) {
+            log.warn("[OAuth2] loadAuthorizationRequest: cookie present but deserialization returned null");
+        }
+        return authRequest;
     }
 
     @Override
@@ -33,11 +46,15 @@ public class CookieOAuth2AuthorizationRequestRepository
             deleteCookie(request, response);
             return;
         }
-        Cookie cookie = new Cookie(COOKIE_NAME, serialize(authorizationRequest));
+        String serialized = serialize(authorizationRequest);
+        boolean secure = isSecureRequest(request);
+        log.debug("[OAuth2] saveAuthorizationRequest: setting cookie, valueLength={}, secure={}, state={}",
+                serialized.length(), secure, authorizationRequest.getState());
+        Cookie cookie = new Cookie(COOKIE_NAME, serialized);
         cookie.setPath("/");
         cookie.setHttpOnly(true);
         cookie.setMaxAge(COOKIE_MAX_AGE);
-        cookie.setSecure(isSecureRequest(request));
+        cookie.setSecure(secure);
         cookie.setAttribute("SameSite", "Lax");
         response.addCookie(cookie);
     }
@@ -82,6 +99,7 @@ public class CookieOAuth2AuthorizationRequestRepository
             return (OAuth2AuthorizationRequest) SerializationUtils.deserialize(
                     Base64.getUrlDecoder().decode(value));
         } catch (Exception e) {
+            log.error("[OAuth2] deserialize failed: {} - {}", e.getClass().getSimpleName(), e.getMessage());
             return null;
         }
     }

--- a/src/main/java/com/hub/api/admin/security/CustomUserDetails.java
+++ b/src/main/java/com/hub/api/admin/security/CustomUserDetails.java
@@ -1,6 +1,5 @@
 package com.hub.api.admin.security;
 
-import com.hub.api.admin.entity.Role;
 import com.hub.api.admin.entity.User;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;


### PR DESCRIPTION
## Summary

- Add `WARN` log when `oauth2_auth_request` cookie is missing on callback (includes list of present cookies)
- Add `WARN` log when cookie is present but deserialization returns null
- Add `ERROR` log with exception class + message when deserialization throws
- Add `DEBUG` log when cookie is saved (value length, secure flag, state)
- Remove unused `Role` import in `CustomUserDetails`

Closes #24

## Cách đọc log sau khi deploy

Khi lỗi xảy ra, tìm trong log một trong hai pattern sau:

**Case A — cookie không được gửi bởi browser:**
```
WARN [OAuth2] loadAuthorizationRequest: cookie 'oauth2_auth_request' NOT found. uri=..., presentCookies=[...]
```

**Case B — cookie có nhưng deserialization fail:**
```
WARN [OAuth2] loadAuthorizationRequest: cookie present but deserialization returned null
ERROR [OAuth2] deserialize failed: InvalidClassException - ...
```

Kết quả sẽ xác định bước fix tiếp theo.

## Test plan

- [ ] Deploy và reproduce lỗi
- [ ] Kiểm tra log để xác định Case A hay Case B
- [ ] Báo lại kết quả để tiến hành fix dứt điểm

🤖 Generated with [Claude Code](https://claude.com/claude-code)