### PR TITLE
fix: compilation failure in OAuth2LoginSuccessHandler after cookie repo removal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,16 @@ mvn spring-boot:run
 docker buildx build --platform linux/amd64 -t <image>:tag --push .
 ```
 
+## Pre-commit requirement
+
+**Bắt buộc chạy build thành công trước khi commit.** Dùng lệnh sau để kiểm tra:
+
+```bash
+mvn clean package -DskipTests
+```
+
+Chỉ được phép commit khi output kết thúc bằng `BUILD SUCCESS`. Nếu build fail, phải fix lỗi trước.
+
 ## Architecture
 
 Spring Boot 3.5.7 REST API (Java 21) with JWT authentication, MongoDB persistence, and RBAC. Runs on port 8080, context path `/api`.

--- a/src/main/java/com/hub/api/admin/security/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/hub/api/admin/security/OAuth2LoginSuccessHandler.java
@@ -21,17 +21,14 @@ import java.util.Map;
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private final JwtService jwtService;
-    private final CookieOAuth2AuthorizationRequestRepository cookieRepo;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final String frontendRedirectUri;
 
     public OAuth2LoginSuccessHandler(
             JwtService jwtService,
-            CookieOAuth2AuthorizationRequestRepository cookieRepo,
             CustomOAuth2UserService customOAuth2UserService,
             @Value("${app.oauth2.frontend-redirect-uri}") String frontendRedirectUri) {
         this.jwtService = jwtService;
-        this.cookieRepo = cookieRepo;
         this.customOAuth2UserService = customOAuth2UserService;
         this.frontendRedirectUri = frontendRedirectUri;
     }
@@ -70,8 +67,6 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         Map<String, Object> extraClaims = Map.of("roles", roles, "permissions", permissions);
         String jwt = jwtService.generateToken(new CustomUserDetails(user), extraClaims);
 
-        cookieRepo.removeAuthorizationRequest(request, response);
-
-        response.sendRedirect(frontendRedirectUri + "?token=" + jwt  + "&username=" + user.getUsername());
+        response.sendRedirect(frontendRedirectUri + "?token=" + jwt + "&username=" + user.getUsername());
     }
 }


### PR DESCRIPTION
## Summary

- Remove `CookieOAuth2AuthorizationRequestRepository` dependency from `OAuth2LoginSuccessHandler`
- Remove redundant `cookieRepo.removeAuthorizationRequest()` call (Spring Security handles this automatically)
- Update `CLAUDE.md`: require `mvn clean package -DskipTests` to pass before any commit

Closes #28

## Test plan

- [ ] `mvn clean package -DskipTests` → BUILD SUCCESS
- [ ] Deploy và test Google OAuth2 login

🤖 Generated with [Claude Code](https://claude.com/claude-code)