### PR TITLE
revert: restore cookie-based OAuth2 authorization request storage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,12 +62,6 @@
             <artifactId>spring-boot-starter-data-mongodb</artifactId>
         </dependency>
 
-        <!-- Spring Session (store OAuth2 state in MongoDB, shared across pods) -->
-        <dependency>
-            <groupId>org.springframework.session</groupId>
-            <artifactId>spring-session-data-mongodb</artifactId>
-        </dependency>
-
         <!-- JWT (jjwt) -->
         <dependency>
             <groupId>io.jsonwebtoken</groupId>

--- a/src/main/java/com/hub/api/admin/config/SecurityConfig.java
+++ b/src/main/java/com/hub/api/admin/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.hub.api.admin.config;
 
+import com.hub.api.admin.security.CookieOAuth2AuthorizationRequestRepository;
 import com.hub.api.admin.security.CustomOAuth2UserService;
 import com.hub.api.admin.security.JwtAuthenticationFilter;
 import com.hub.api.admin.security.OAuth2LoginFailureHandler;
@@ -22,13 +23,16 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
     private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+    private final CookieOAuth2AuthorizationRequestRepository cookieRepo;
 
     public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter,
                           OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler,
-                          OAuth2LoginFailureHandler oAuth2LoginFailureHandler) {
+                          OAuth2LoginFailureHandler oAuth2LoginFailureHandler,
+                          CookieOAuth2AuthorizationRequestRepository cookieRepo) {
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
         this.oAuth2LoginSuccessHandler = oAuth2LoginSuccessHandler;
         this.oAuth2LoginFailureHandler = oAuth2LoginFailureHandler;
+        this.cookieRepo = cookieRepo;
     }
 
     @Bean
@@ -54,6 +58,7 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2
+                        .authorizationEndpoint(a -> a.authorizationRequestRepository(cookieRepo))
                         .userInfoEndpoint(u -> u.userService(customOAuth2UserService))
                         .successHandler(oAuth2LoginSuccessHandler)
                         .failureHandler(oAuth2LoginFailureHandler)

--- a/src/main/java/com/hub/api/admin/security/CookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/hub/api/admin/security/CookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,107 @@
+package com.hub.api.admin.security;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.util.SerializationUtils;
+
+import java.util.Arrays;
+import java.util.Base64;
+
+@Slf4j
+@Component
+public class CookieOAuth2AuthorizationRequestRepository
+        implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+    private static final String COOKIE_NAME = "oauth2_auth_request";
+    private static final int COOKIE_MAX_AGE = 180; // 3 minutes
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        java.util.Optional<String> cookieValue = getCookieValue(request, COOKIE_NAME);
+        if (cookieValue.isEmpty()) {
+            String cookieNames = request.getCookies() == null ? "none" :
+                    Arrays.stream(request.getCookies()).map(Cookie::getName).toList().toString();
+            log.warn("[OAuth2] loadAuthorizationRequest: cookie '{}' NOT found. uri={}, presentCookies={}",
+                    COOKIE_NAME, request.getRequestURI(), cookieNames);
+            return null;
+        }
+        log.debug("[OAuth2] loadAuthorizationRequest: cookie found, valueLength={}", cookieValue.get().length());
+        OAuth2AuthorizationRequest authRequest = deserialize(cookieValue.get());
+        if (authRequest == null) {
+            log.warn("[OAuth2] loadAuthorizationRequest: cookie present but deserialization returned null");
+        }
+        return authRequest;
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest,
+                                         HttpServletRequest request,
+                                         HttpServletResponse response) {
+        if (authorizationRequest == null) {
+            log.warn("[OAuth2] saveAuthorizationRequest: null authorizationRequest, deleting cookie");
+            deleteCookie(request, response);
+            return;
+        }
+        String serialized = serialize(authorizationRequest);
+        boolean secure = isSecureRequest(request);
+        log.debug("[OAuth2] saveAuthorizationRequest: setting cookie, valueLength={}, secure={}, state={}",
+                serialized.length(), secure, authorizationRequest.getState());
+        Cookie cookie = new Cookie(COOKIE_NAME, serialized);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(COOKIE_MAX_AGE);
+        cookie.setSecure(secure);
+        cookie.setAttribute("SameSite", "Lax");
+        response.addCookie(cookie);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request,
+                                                                  HttpServletResponse response) {
+        OAuth2AuthorizationRequest authRequest = loadAuthorizationRequest(request);
+        deleteCookie(request, response);
+        return authRequest;
+    }
+
+    private java.util.Optional<String> getCookieValue(HttpServletRequest request, String name) {
+        if (request.getCookies() == null) return java.util.Optional.empty();
+        return Arrays.stream(request.getCookies())
+                .filter(c -> c.getName().equals(name))
+                .map(Cookie::getValue)
+                .findFirst();
+    }
+
+    private boolean isSecureRequest(HttpServletRequest request) {
+        return request.isSecure()
+                || "https".equalsIgnoreCase(request.getHeader("X-Forwarded-Proto"));
+    }
+
+    private void deleteCookie(HttpServletRequest request, HttpServletResponse response) {
+        Cookie cookie = new Cookie(COOKIE_NAME, "");
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(0);
+        cookie.setSecure(isSecureRequest(request));
+        cookie.setAttribute("SameSite", "Lax");
+        response.addCookie(cookie);
+    }
+
+    private String serialize(OAuth2AuthorizationRequest request) {
+        return Base64.getUrlEncoder().encodeToString(SerializationUtils.serialize(request));
+    }
+
+    private OAuth2AuthorizationRequest deserialize(String value) {
+        try {
+            return (OAuth2AuthorizationRequest) SerializationUtils.deserialize(
+                    Base64.getUrlDecoder().decode(value));
+        } catch (Exception e) {
+            log.error("[OAuth2] deserialize failed: {} - {}", e.getClass().getSimpleName(), e.getMessage());
+            return null;
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,11 +4,6 @@ server:
     context-path: /api
   forward-headers-strategy: NATIVE
 spring:
-  session:
-    store-type: mongodb
-    mongodb:
-      collection-name: sessions
-    timeout: 10m
   data:
     mongodb:
       uri: ${MONGODB_URI:mongodb://localhost:27017/admin_db}


### PR DESCRIPTION
Closes #30

## Summary
- Restore `CookieOAuth2AuthorizationRequestRepository.java` (deleted in PR #27)
- Wire cookie repo back in `SecurityConfig`
- Remove `spring-session-data-mongodb` from `pom.xml`
- Remove `spring.session` block from `application.yml`

## Why
Spring Session approach (PR #27) still fails with `authorization_request_not_found` in production — reverting to cookie-based state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)