### PR TITLE
fix: switch OAuth2 to session-based state storage

### DIFF
--- a/src/main/java/com/hub/api/admin/config/SecurityConfig.java
+++ b/src/main/java/com/hub/api/admin/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package com.hub.api.admin.config;
 
-import com.hub.api.admin.security.CookieOAuth2AuthorizationRequestRepository;
 import com.hub.api.admin.security.CustomOAuth2UserService;
 import com.hub.api.admin.security.JwtAuthenticationFilter;
 import com.hub.api.admin.security.OAuth2LoginFailureHandler;
@@ -23,16 +22,13 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
     private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
-    private final CookieOAuth2AuthorizationRequestRepository cookieRepo;
 
     public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter,
                           OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler,
-                          OAuth2LoginFailureHandler oAuth2LoginFailureHandler,
-                          CookieOAuth2AuthorizationRequestRepository cookieRepo) {
+                          OAuth2LoginFailureHandler oAuth2LoginFailureHandler) {
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
         this.oAuth2LoginSuccessHandler = oAuth2LoginSuccessHandler;
         this.oAuth2LoginFailureHandler = oAuth2LoginFailureHandler;
-        this.cookieRepo = cookieRepo;
     }
 
     @Bean
@@ -58,7 +54,6 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2
-                        .authorizationEndpoint(a -> a.authorizationRequestRepository(cookieRepo))
                         .userInfoEndpoint(u -> u.userService(customOAuth2UserService))
                         .successHandler(oAuth2LoginSuccessHandler)
                         .failureHandler(oAuth2LoginFailureHandler)


### PR DESCRIPTION
Closes #35

## Summary
- Remove `CookieOAuth2AuthorizationRequestRepository` from `SecurityConfig`
- Spring Security falls back to default `HttpSessionOAuth2AuthorizationRequestRepository`
- State is stored server-side in HTTP session instead of browser cookie
- Nginx ingress sticky sessions (added in ArgoCD repo) ensure same pod handles init + callback

## Why cookie approach fails in production
`presentCookies=none` — browser sends zero cookies with the callback. The `oauth2_auth_request` cookie is never returned, regardless of `SameSite=None`. This is a cross-site / frontend initiation issue.

## Architecture after fix
```
Browser → nginx (INGRESSSESSION cookie → same pod) → Spring pod
                                                      └── HTTP Session stores OAuth2 state
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)