### PR TITLE
fix: replace large OAuth2 cookie with MongoDB-backed state storage

### DIFF
--- a/src/main/java/com/hub/api/admin/config/SecurityConfig.java
+++ b/src/main/java/com/hub/api/admin/config/SecurityConfig.java
@@ -1,8 +1,8 @@
 package com.hub.api.admin.config;
 
-import com.hub.api.admin.security.CookieOAuth2AuthorizationRequestRepository;
 import com.hub.api.admin.security.CustomOAuth2UserService;
 import com.hub.api.admin.security.JwtAuthenticationFilter;
+import com.hub.api.admin.security.MongoOAuth2AuthorizationRequestRepository;
 import com.hub.api.admin.security.OAuth2LoginFailureHandler;
 import com.hub.api.admin.security.OAuth2LoginSuccessHandler;
 import org.springframework.context.annotation.Bean;
@@ -23,16 +23,16 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
     private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
-    private final CookieOAuth2AuthorizationRequestRepository cookieRepo;
+    private final MongoOAuth2AuthorizationRequestRepository mongoRepo;
 
     public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter,
                           OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler,
                           OAuth2LoginFailureHandler oAuth2LoginFailureHandler,
-                          CookieOAuth2AuthorizationRequestRepository cookieRepo) {
+                          MongoOAuth2AuthorizationRequestRepository mongoRepo) {
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
         this.oAuth2LoginSuccessHandler = oAuth2LoginSuccessHandler;
         this.oAuth2LoginFailureHandler = oAuth2LoginFailureHandler;
-        this.cookieRepo = cookieRepo;
+        this.mongoRepo = mongoRepo;
     }
 
     @Bean
@@ -58,7 +58,7 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2
-                        .authorizationEndpoint(a -> a.authorizationRequestRepository(cookieRepo))
+                        .authorizationEndpoint(a -> a.authorizationRequestRepository(mongoRepo))
                         .userInfoEndpoint(u -> u.userService(customOAuth2UserService))
                         .successHandler(oAuth2LoginSuccessHandler)
                         .failureHandler(oAuth2LoginFailureHandler)

--- a/src/main/java/com/hub/api/admin/entity/OAuth2StateDocument.java
+++ b/src/main/java/com/hub/api/admin/entity/OAuth2StateDocument.java
@@ -1,0 +1,31 @@
+package com.hub.api.admin.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.Date;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Document(collection = "oauth2_states")
+public class OAuth2StateDocument {
+
+    @Id
+    private String state;
+
+    private String serializedRequest;
+
+    @Indexed(expireAfterSeconds = 300) // 5 minutes TTL
+    private Date createdAt = new Date();
+
+    public OAuth2StateDocument(String state, String serializedRequest) {
+        this.state = state;
+        this.serializedRequest = serializedRequest;
+        this.createdAt = new Date();
+    }
+}

--- a/src/main/java/com/hub/api/admin/repository/OAuth2StateRepository.java
+++ b/src/main/java/com/hub/api/admin/repository/OAuth2StateRepository.java
@@ -1,0 +1,7 @@
+package com.hub.api.admin.repository;
+
+import com.hub.api.admin.entity.OAuth2StateDocument;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface OAuth2StateRepository extends MongoRepository<OAuth2StateDocument, String> {
+}

--- a/src/main/java/com/hub/api/admin/security/MongoOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/hub/api/admin/security/MongoOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,95 @@
+package com.hub.api.admin.security;
+
+import com.hub.api.admin.entity.OAuth2StateDocument;
+import com.hub.api.admin.repository.OAuth2StateRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.util.SerializationUtils;
+
+import java.util.Base64;
+
+/**
+ * Stores OAuth2 authorization requests in MongoDB keyed by the `state` parameter.
+ * <p>
+ * This avoids large (2 KB+) cookies that are unreliable behind nginx ingress in
+ * Kubernetes environments. The OAuth2 `state` value is already included in Google's
+ * callback URL, so it can be used directly to look up the saved request — no cookie needed.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MongoOAuth2AuthorizationRequestRepository
+        implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+    private final OAuth2StateRepository stateRepository;
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        String state = request.getParameter("state");
+        if (state == null) {
+            return null;
+        }
+        return stateRepository.findById(state)
+                .map(doc -> {
+                    log.debug("[OAuth2] loadAuthorizationRequest: found state={}", state);
+                    return deserialize(doc.getSerializedRequest());
+                })
+                .orElseGet(() -> {
+                    log.warn("[OAuth2] loadAuthorizationRequest: state not found in MongoDB: {}", state);
+                    return null;
+                });
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest,
+                                         HttpServletRequest request,
+                                         HttpServletResponse response) {
+        if (authorizationRequest == null) {
+            String state = request.getParameter("state");
+            if (state != null) {
+                stateRepository.deleteById(state);
+                log.debug("[OAuth2] saveAuthorizationRequest: deleted state={}", state);
+            }
+            return;
+        }
+        String state = authorizationRequest.getState();
+        String serialized = serialize(authorizationRequest);
+        stateRepository.save(new OAuth2StateDocument(state, serialized));
+        log.info("[OAuth2] saveAuthorizationRequest: saved state={}, serializedLength={}", state, serialized.length());
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request,
+                                                                  HttpServletResponse response) {
+        String state = request.getParameter("state");
+        if (state == null) {
+            return null;
+        }
+        return stateRepository.findById(state)
+                .map(doc -> {
+                    stateRepository.deleteById(state);
+                    log.debug("[OAuth2] removeAuthorizationRequest: removed state={}", state);
+                    return deserialize(doc.getSerializedRequest());
+                })
+                .orElse(null);
+    }
+
+    private String serialize(OAuth2AuthorizationRequest request) {
+        return Base64.getUrlEncoder().encodeToString(SerializationUtils.serialize(request));
+    }
+
+    private OAuth2AuthorizationRequest deserialize(String value) {
+        try {
+            return (OAuth2AuthorizationRequest) SerializationUtils.deserialize(
+                    Base64.getUrlDecoder().decode(value));
+        } catch (Exception e) {
+            log.error("[OAuth2] deserialize failed: {} - {}", e.getClass().getSimpleName(), e.getMessage());
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Closes #37

## Summary
- Replace `CookieOAuth2AuthorizationRequestRepository` (2672-byte cookie) with `MongoOAuth2AuthorizationRequestRepository`
- OAuth2 authorization request state is now stored in MongoDB `oauth2_states` collection with a 5-minute TTL index
- The `state` parameter in Google's callback URL is used to look up the saved request — no cookie needed

## Changes
- `entity/OAuth2StateDocument.java` — new MongoDB document with TTL index
- `repository/OAuth2StateRepository.java` — Spring Data repository
- `security/MongoOAuth2AuthorizationRequestRepository.java` — stateless, cookie-free implementation
- `config/SecurityConfig.java` — wired to use the new repository

## Test plan
- [ ] Trigger Google OAuth2 login on `https://www.devapihub.com`
- [ ] Verify callback succeeds (no `authorization_request_not_found` error)
- [ ] Verify JWT token is returned and user can access protected endpoints
- [ ] Verify `oauth2_states` documents in MongoDB are auto-deleted after 5 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)